### PR TITLE
Allow for inclusion of specific team tag to include PR in the list

### DIFF
--- a/src/get_pull_requests.js
+++ b/src/get_pull_requests.js
@@ -3,6 +3,7 @@ const axios = require("axios");
 const gitHubRepositories = process.env.GitHubRepositories.replace(/ /g,'').split(',');
 const gitHubAuthorList = process.env.GitHubAuthors.replace(/ /g,'').split(',');
 const gitHubAccessToken = process.env.GitHubAccessToken;
+const gitHubTeamTag = process.env.GitHubTeamTag;
 
 async function getPullRequests() {
   const promises = gitHubRepositories.map(repository =>
@@ -13,12 +14,20 @@ async function getPullRequests() {
   const filteredPullRequests = pullRequestResponses.map(pullRequestResponse => {
     return pullRequestResponse.data.filter(pullRequest => {
       var pullRequestAuthor = pullRequest.user.login;
-      return gitHubAuthorList.includes(pullRequestAuthor);
+      return (gitHubAuthorList.includes(pullRequestAuthor) || bodyIncludesTag(pullRequest, gitHubTeamTag));
    });
   });
 
   const pullRequests = [].concat(...filteredPullRequests);
   return pullRequests;
+}
+
+function bodyIncludesTag(pullRequest, teamTag) {
+  if (typeof teamTag === 'undefined') {
+    return false;
+  } else {
+    return pullRequest.body.includes(teamTag);
+  }
 }
 
 module.exports = getPullRequests;


### PR DESCRIPTION
Now that the CX team has sub-teams created in github (i.e. @homechef/tech-cx-messaging) I would like to allow for this option to be configured within the Slackbot so that those not noted as specific authors within a group (ahem...me...) can still tag PRs for review by a specific team. 

Did not include a spec 😬 